### PR TITLE
Add randomUUID fallback for non-Web Crypto environments

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -210,9 +210,14 @@ function TableView({
 }
 
 // Helpers used here (kept local for simplicity)
+function fallbackId() {
+  return (
+    Date.now().toString(36) + Math.random().toString(36).slice(2)
+  );
+}
 function normalizeItem(x) {
   return {
-    id: x.id || crypto.randomUUID(),
+    id: x.id || (globalThis.crypto?.randomUUID?.() ?? fallbackId()),
     name: x.name,
     amount: Number(x.amount || 0),
     cycle: x.cycle || "monthly",


### PR DESCRIPTION
## Summary
- generate IDs with Web Crypto's `randomUUID` when available, falling back to a timestamp/Math.random implementation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5c5b3146883299191f53419851812