### PR TITLE
fix: use relative base path for builds

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,16 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-// If deploying to username.github.io/repo-name, set env var VITE_BASE="/repo-name/"
+// When the site is built without an explicit base path, Vite assumes
+// the app is served from the server root (`/`). This breaks when the
+// bundle is opened from a subdirectory (e.g. GitHub Pages) because the
+// generated HTML references assets at `/assets/...`, resulting in 404s
+// like `index-*.css` or `index-*.js` not being found.  By falling back
+// to a relative path (`./`), the built HTML will reference assets
+// relative to its own location and work regardless of where it's
+// hosted.  The `VITE_BASE` environment variable can still override this
+// when a custom absolute base is desired.
 export default defineConfig({
   plugins: [react()],
-  base: process.env.VITE_BASE || "/",
+  base: process.env.VITE_BASE || "./",
 });


### PR DESCRIPTION
## Summary
- default Vite base path to relative `./` when not specified via `VITE_BASE`
- prevents missing asset 404s when serving the built site from a subdirectory

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5cd36c4708329a59b600375d24a2d