### PR TITLE
Fix yearly interval handling across timezones

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -6,16 +6,22 @@ export function daysBetween(a, b) {
 }
 
 export function addInterval(date, cycle, intervalDays = 30) {
-  const d = new Date(date);
+  // Parse as local date to avoid timezone offsets from ISO strings
+  const [y, m, d0] = date.split("-").map(Number);
+  const d = new Date(y, (m || 1) - 1, d0 || 1);
   if (cycle === "weekly") d.setDate(d.getDate() + 7);
   else if (cycle === "monthly") d.setMonth(d.getMonth() + 1);
   else if (cycle === "yearly") {
     const month = d.getMonth();
     d.setFullYear(d.getFullYear() + 1);
     if (d.getMonth() !== month) d.setDate(0);
-  } else if (cycle === "custom")
+  } else if (cycle === "custom") {
     d.setDate(d.getDate() + Number(intervalDays || 30));
-  return d.toISOString().slice(0, 10);
+  }
+  const yr = d.getFullYear();
+  const mo = String(d.getMonth() + 1).padStart(2, "0");
+  const da = String(d.getDate()).padStart(2, "0");
+  return `${yr}-${mo}-${da}`;
 }
 
 export function formatCurrency(n, symbol = "$") {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -19,6 +19,13 @@ describe("utils", () => {
     expect(y === "2025-02-28" || y.startsWith("2025-02")).toBe(true);
     expect(addInterval("2025-01-01", "custom", 10)).toBe("2025-01-11");
   });
+  it("addInterval yearly handles leap years in different timezones", () => {
+    const prev = process.env.TZ;
+    process.env.TZ = "America/New_York";
+    const y = addInterval("2024-02-29", "yearly");
+    expect(y).toBe("2025-02-28");
+    process.env.TZ = prev;
+  });
   it("monthlyEquivalent conversions", () => {
     expect(Math.abs(monthlyEquivalent(10, "weekly") - 43.4524)).toBeLessThan(
       1e-6,


### PR DESCRIPTION
## Summary
- parse dates as local components in `addInterval` to avoid timezone-induced leap year errors
- cover leap-year interval logic across timezones with new test

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5cf1c959483298da6a365e929d12a