### PR TITLE
feat: add bubble selection toolbar

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -147,3 +147,13 @@ export function parseHue(hsl) {
   const m = /hsl\(([^\s]+)\s/.exec(hsl);
   return m ? parseFloat(m[1]) : NaN;
 }
+
+// Toggle selection ids with optional multi-select (shift-click)
+export function updateSelection(selected, id, multi = false) {
+  if (multi) {
+    return selected.includes(id)
+      ? selected.filter((x) => x !== id)
+      : [...selected, id];
+  }
+  return selected.includes(id) ? [] : [id];
+}

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -6,6 +6,7 @@ import {
   dueColor,
   parseHue,
   packCircles,
+  updateSelection,
 } from "../src/lib/utils.js";
 
 describe("utils", () => {
@@ -58,5 +59,17 @@ describe("utils", () => {
         expect(dist + 0.25).toBeGreaterThanOrEqual(A.r + B.r); // epsilon
       }
     }
+  });
+
+  it("updateSelection toggles ids with optional multi-select", () => {
+    let sel = [];
+    sel = updateSelection(sel, "a", false);
+    expect(sel).toEqual(["a"]);
+    sel = updateSelection(sel, "b", true);
+    expect(sel.sort()).toEqual(["a", "b"]);
+    sel = updateSelection(sel, "a", true);
+    expect(sel).toEqual(["b"]);
+    sel = updateSelection(sel, "b", false);
+    expect(sel).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- add updateSelection helper for multi-select
- enable selecting bubbles and batch actions via toolbar
- test selection utility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b342e62ce88329aa41cef57b356e62