### PR TITLE
feat: add theme mode selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="/favicon.svg" />
     <title>Subscription Bubble Tracker</title>
+    <script>
+      (()=>{
+        const theme=localStorage.getItem('theme')||'system';
+        const prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if(theme==='dark'||(theme==='system'&&prefersDark)){
+          document.documentElement.classList.add('dark');
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -68,6 +68,7 @@ export default function SubscriptionBubbleTracker(){
   const [filter, setFilter] = useState("all"); // all | overdue | autopay | manual
   const [sortBy, setSortBy] = useState("due"); // due | amount | name | category
   const [view, setView] = useState("bubbles"); // bubbles | table | shader
+  const [theme, setTheme] = useState(() => localStorage.getItem("theme") || "system");
   const [items, setItems] = useState(() => {
     const raw = localStorage.getItem(STORAGE_KEY);
     if(!raw) return hydrate(SAMPLE);
@@ -141,30 +142,59 @@ export default function SubscriptionBubbleTracker(){
   function handleAddQuick(){ setItems(prev=>[...prev, normalizeItem({ name:'New', category:'', amount:10, cycle:'monthly', intervalDays:30, nextDue:new Date().toISOString().slice(0,10), autopay:true })]); }
   function updateRow(id, patch){ setItems(prev => prev.map(p => p.id===id ? normalizeItem({...p, ...patch}) : p)); }
 
+  useEffect(() => {
+    const root = document.documentElement;
+    const apply = () => {
+      if (theme === "dark") {
+        root.classList.add("dark");
+      } else if (theme === "light") {
+        root.classList.remove("dark");
+      } else {
+        if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+          root.classList.add("dark");
+        } else {
+          root.classList.remove("dark");
+        }
+      }
+    };
+    apply();
+    localStorage.setItem("theme", theme);
+    if (theme === "system") {
+      const m = window.matchMedia("(prefers-color-scheme: dark)");
+      m.addEventListener("change", apply);
+      return () => m.removeEventListener("change", apply);
+    }
+  }, [theme]);
+
   return (
-    <div className="w-full min-h-screen bg-neutral-950 text-neutral-100 p-4 md:p-6">
+    <div className="w-full min-h-screen bg-neutral-50 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100 p-4 md:p-6">
       <div className="max-w-7xl mx-auto">
         <header className="flex flex-col md:flex-row gap-3 md:items-end md:justify-between">
           <div>
             <h1 className="text-2xl md:text-3xl font-semibold tracking-tight">Subscription Tracker</h1>
-            <p className="text-neutral-400 text-sm md:text-base">Primary view: bubbles. Secondary view: table for quick edits.</p>
+            <p className="text-neutral-600 dark:text-neutral-400 text-sm md:text-base">Primary view: bubbles. Secondary view: table for quick edits.</p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
-            <div className="inline-flex p-1 rounded-2xl bg-neutral-800 ring-1 ring-white/10">
-              <button onClick={()=>setView('bubbles')} className={`px-3 py-1.5 rounded-xl text-sm font-medium ${view==='bubbles'?'bg-white text-neutral-900':'text-neutral-300 hover:text-white'}`}>Bubbles</button>
-              <button onClick={()=>setView('table')} className={`px-3 py-1.5 rounded-xl text-sm font-medium ${view==='table'?'bg-white text-neutral-900':'text-neutral-300 hover:text-white'}`}>Table</button>
-              <button onClick={()=>setView('shader')} className={`px-3 py-1.5 rounded-xl text-sm font-medium ${view==='shader'?'bg-white text-neutral-900':'text-neutral-300 hover:text-white'}`}>Shader</button>
+            <div className="inline-flex p-1 rounded-2xl bg-neutral-200 dark:bg-neutral-800 ring-1 ring-black/10 dark:ring-white/10">
+              <button onClick={()=>setView('bubbles')} className={`px-3 py-1.5 rounded-xl text-sm font-medium ${view==='bubbles'?'bg-white text-neutral-900':'text-neutral-700 hover:text-neutral-900 dark:text-neutral-300 dark:hover:text-white'}`}>Bubbles</button>
+              <button onClick={()=>setView('table')} className={`px-3 py-1.5 rounded-xl text-sm font-medium ${view==='table'?'bg-white text-neutral-900':'text-neutral-700 hover:text-neutral-900 dark:text-neutral-300 dark:hover:text-white'}`}>Table</button>
+              <button onClick={()=>setView('shader')} className={`px-3 py-1.5 rounded-xl text-sm font-medium ${view==='shader'?'bg-white text-neutral-900':'text-neutral-700 hover:text-neutral-900 dark:text-neutral-300 dark:hover:text-white'}`}>Shader</button>
             </div>
+            <select value={theme} onChange={e=>setTheme(e.target.value)} className="px-3 py-2 rounded-2xl bg-neutral-200 dark:bg-neutral-800 ring-1 ring-black/10 dark:ring-white/10 text-sm">
+              <option value="system">System</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
             <button onClick={()=>{setEditing(null); setShowForm(true);}} className="px-3 py-2 rounded-2xl bg-white text-neutral-900 text-sm font-medium shadow hover:shadow-md transition">Add Subscription</button>
-            <label className="px-3 py-2 rounded-2xl bg-neutral-800 text-sm cursor-pointer hover:bg-neutral-700 transition">Import JSON<input type="file" onChange={handleImport} accept="application/json" className="hidden"/></label>
-            <button onClick={handleExport} className="px-3 py-2 rounded-2xl bg-neutral-800 text-sm hover:bg-neutral-700 transition">Export JSON</button>
+            <label className="px-3 py-2 rounded-2xl bg-neutral-200 dark:bg-neutral-800 text-sm cursor-pointer hover:bg-neutral-300 dark:hover:bg-neutral-700 transition">Import JSON<input type="file" onChange={handleImport} accept="application/json" className="hidden"/></label>
+            <button onClick={handleExport} className="px-3 py-2 rounded-2xl bg-neutral-200 dark:bg-neutral-800 text-sm hover:bg-neutral-300 dark:hover:bg-neutral-700 transition">Export JSON</button>
           </div>
         </header>
 
         <div className="mt-4 grid grid-cols-1 xl:grid-cols-4 gap-3">
           <div className="xl:col-span-3">
             {view==='bubbles' ? (
-              <div ref={ref} className="relative h-[56vh] min-h-[420px] rounded-3xl bg-neutral-900/70 ring-1 ring-white/10 overflow-hidden">
+              <div ref={ref} className="relative h-[56vh] min-h-[420px] rounded-3xl bg-neutral-100 dark:bg-neutral-900/70 ring-1 ring-black/10 dark:ring-white/10 overflow-hidden">
                 {sorted.map(it => {
                   const p = pos.get(it.id) || {x:60,y:60};
                   const r = (()=>{ const {min,max}=amountRange; const rMin=28, rMax=Math.min(140, Math.floor(Math.min(size.w,size.h)*0.28)); if(max===min) return (rMin+rMax)/2; return rMin + (rMax-rMin)*((it.amount-min)/(max-min)); })();
@@ -192,7 +222,7 @@ export default function SubscriptionBubbleTracker(){
                 )}
               </div>
             ) : view==='shader' ? (
-              <div ref={ref} className="relative h-[56vh] min-h-[420px] rounded-3xl bg-neutral-900/70 ring-1 ring-white/10 overflow-hidden">
+              <div ref={ref} className="relative h-[56vh] min-h-[420px] rounded-3xl bg-neutral-100 dark:bg-neutral-900/70 ring-1 ring-black/10 dark:ring-white/10 overflow-hidden">
                 <ShaderBubbleView items={sorted} pos={pos} size={size} amountToRadius={amountToRadius} />
               </div>
             ) : (
@@ -209,38 +239,38 @@ export default function SubscriptionBubbleTracker(){
           </div>
 
           <aside className="xl:col-span-1 flex flex-col gap-3">
-            <div className="rounded-3xl bg-neutral-900/70 ring-1 ring-white/10 p-4">
-              <div className="flex items-center gap-2"><span className="text-sm text-neutral-400">Currency</span>
-                <input value={currency} onChange={e=>setCurrency(e.target.value)} className="w-16 px-2 py-1 rounded-lg bg-neutral-800 ring-1 ring-white/10"/>
+            <div className="rounded-3xl bg-neutral-100 dark:bg-neutral-900/70 ring-1 ring-black/10 dark:ring-white/10 p-4">
+              <div className="flex items-center gap-2"><span className="text-sm text-neutral-600 dark:text-neutral-400">Currency</span>
+                <input value={currency} onChange={e=>setCurrency(e.target.value)} className="w-16 px-2 py-1 rounded-lg bg-white dark:bg-neutral-800 ring-1 ring-black/10 dark:ring-white/10"/>
               </div>
               <div className="mt-3">
-                <label className="text-sm text-neutral-300">Lookahead window: <span className="font-medium">{lookahead} days</span></label>
+                <label className="text-sm text-neutral-700 dark:text-neutral-300">Lookahead window: <span className="font-medium">{lookahead} days</span></label>
                 <input type="range" min={7} max={90} value={lookahead} onChange={e=>setLookahead(Number(e.target.value))} className="w-full"/>
                 <ColorLegend />
               </div>
               <div className="mt-3 grid grid-cols-2 gap-2">
-                <select value={filter} onChange={e=>setFilter(e.target.value)} className="col-span-1 px-2 py-2 rounded-xl bg-neutral-800 ring-1 ring-white/10 text-sm">
+                <select value={filter} onChange={e=>setFilter(e.target.value)} className="col-span-1 px-2 py-2 rounded-xl bg-white dark:bg-neutral-800 ring-1 ring-black/10 dark:ring-white/10 text-sm">
                   <option value="all">All</option>
                   <option value="overdue">Overdue</option>
                   <option value="autopay">Autopay</option>
                   <option value="manual">Manual</option>
                 </select>
-                <select value={sortBy} onChange={e=>setSortBy(e.target.value)} className="col-span-1 px-2 py-2 rounded-xl bg-neutral-800 ring-1 ring-white/10 text-sm">
+                <select value={sortBy} onChange={e=>setSortBy(e.target.value)} className="col-span-1 px-2 py-2 rounded-xl bg-white dark:bg-neutral-800 ring-1 ring-black/10 dark:ring-white/10 text-sm">
                   <option value="due">Sort by Due</option>
                   <option value="amount">Sort by Amount</option>
                   <option value="name">Sort by Name</option>
                   <option value="category">Sort by Category</option>
                 </select>
-                <input placeholder="Search" value={query} onChange={e=>setQuery(e.target.value)} className="col-span-2 px-3 py-2 rounded-xl bg-neutral-800 ring-1 ring-white/10 text-sm"/>
+                <input placeholder="Search" value={query} onChange={e=>setQuery(e.target.value)} className="col-span-2 px-3 py-2 rounded-xl bg-white dark:bg-neutral-800 ring-1 ring-black/10 dark:ring-white/10 text-sm"/>
               </div>
             </div>
 
-            <div className="rounded-3xl bg-neutral-900/70 ring-1 ring-white/10 p-4">
-              <h3 className="text-sm text-neutral-400">Monthly equivalent</h3>
+            <div className="rounded-3xl bg-neutral-100 dark:bg-neutral-900/70 ring-1 ring-black/10 dark:ring-white/10 p-4">
+              <h3 className="text-sm text-neutral-600 dark:text-neutral-400">Monthly equivalent</h3>
               <div className="mt-1 text-2xl font-semibold">{formatCurrency(monthlyTotal, currency)}</div>
-              <h3 className="mt-4 text-sm text-neutral-400">Yearly total</h3>
+              <h3 className="mt-4 text-sm text-neutral-600 dark:text-neutral-400">Yearly total</h3>
               <div className="mt-1 text-2xl font-semibold">{formatCurrency(yearlyTotal, currency)}</div>
-              <p className="text-xs text-neutral-400 mt-1">Yearly/weekly/custom amounts are converted to monthly estimates to help budget planning. Yearly total is derived from this estimate.</p>
+              <p className="text-xs text-neutral-600 dark:text-neutral-400 mt-1">Yearly/weekly/custom amounts are converted to monthly estimates to help budget planning. Yearly total is derived from this estimate.</p>
             </div>
           </aside>
         </div>
@@ -303,10 +333,10 @@ function Bubble({ x, y, r, color, item, currency, selected, onSelect, onDeselect
 
 function BubbleToolbar({ count, onMarkPaid, onEdit, onDelete }) {
   return (
-    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-20 bg-neutral-900/95 ring-1 ring-white/10 rounded-2xl shadow-xl px-4 py-2 flex items-center gap-2">
-      <span className="text-sm text-neutral-400 mr-2">{count} selected</span>
+    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-20 bg-neutral-100 dark:bg-neutral-900/95 ring-1 ring-black/10 dark:ring-white/10 rounded-2xl shadow-xl px-4 py-2 flex items-center gap-2">
+      <span className="text-sm text-neutral-600 dark:text-neutral-400 mr-2">{count} selected</span>
       <button onClick={onMarkPaid} className="px-3 py-1 rounded-lg bg-white text-neutral-900 text-sm font-semibold">Mark paid</button>
-      <button onClick={onEdit} className="px-3 py-1 rounded-lg bg-neutral-800 text-sm">Edit</button>
+      <button onClick={onEdit} className="px-3 py-1 rounded-lg bg-neutral-200 dark:bg-neutral-800 text-sm">Edit</button>
       <button onClick={onDelete} className="px-3 py-1 rounded-lg bg-red-600/90 text-sm">Delete</button>
     </div>
   );
@@ -316,7 +346,7 @@ function ColorLegend(){
   return (
     <div className="mt-3">
       <div className="h-3 rounded-full w-full" style={{background: 'linear-gradient(90deg, hsl(220 90% 58%), hsl(160 90% 58%), hsl(60 90% 58%), hsl(0 90% 50%))'}}/>
-      <div className="flex justify-between text-[10px] text-neutral-400 mt-1"><span>Far</span><span>Near</span><span>Due</span><span>Overdue</span></div>
+      <div className="flex justify-between text-[10px] text-neutral-600 dark:text-neutral-400 mt-1"><span>Far</span><span>Near</span><span>Due</span><span>Overdue</span></div>
     </div>
   );
 }
@@ -326,7 +356,7 @@ function Modal({ children, onClose }){
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4 z-50" onClick={onClose}>
       <div className="w-full max-w-xl" onClick={(e)=>e.stopPropagation()}>
-        <div className="rounded-3xl bg-neutral-900 ring-1 ring-white/10 p-4 md:p-6 shadow-2xl">{children}</div>
+        <div className="rounded-3xl bg-neutral-50 dark:bg-neutral-900 ring-1 ring-black/10 dark:ring-white/10 p-4 md:p-6 shadow-2xl">{children}</div>
       </div>
     </div>
   );
@@ -339,16 +369,16 @@ function EditForm({ initial, onCancel, onSave, currency }){
     <form className="grid grid-cols-2 gap-3" onSubmit={(e)=>{ e.preventDefault(); onSave(form); }}>
       <h2 className="col-span-2 text-lg font-semibold">{initial?.id ? 'Edit' : 'Add'} Subscription</h2>
       <label className="col-span-2 text-sm">Name
-        <input value={form.name} onChange={e=>set('name', e.target.value)} required className="mt-1 w-full px-3 py-2 rounded-xl bg-neutral-800 ring-1 ring-white/10"/>
+        <input value={form.name} onChange={e=>set('name', e.target.value)} required className="mt-1 w-full px-3 py-2 rounded-xl bg-white dark:bg-neutral-800 ring-1 ring-black/10 dark:ring-white/10"/>
       </label>
       <label className="col-span-2 text-sm">Category
-        <input value={form.category||''} onChange={e=>set('category', e.target.value)} className="mt-1 w-full px-3 py-2 rounded-xl bg-neutral-800 ring-1 ring-white/10"/>
+        <input value={form.category||''} onChange={e=>set('category', e.target.value)} className="mt-1 w-full px-3 py-2 rounded-xl bg-white dark:bg-neutral-800 ring-1 ring-black/10 dark:ring-white/10"/>
       </label>
       <label className="text-sm">Amount ({currency})
-        <input type="number" step="0.01" min="0" value={form.amount} onChange={e=>set('amount', parseFloat(e.target.value))} required className="mt-1 w-full px-3 py-2 rounded-xl bg-neutral-800 ring-1 ring-white/10"/>
+        <input type="number" step="0.01" min="0" value={form.amount} onChange={e=>set('amount', parseFloat(e.target.value))} required className="mt-1 w-full px-3 py-2 rounded-xl bg-white dark:bg-neutral-800 ring-1 ring-black/10 dark:ring-white/10"/>
       </label>
       <label className="text-sm">Cycle
-        <select value={form.cycle} onChange={e=>set('cycle', e.target.value)} className="mt-1 w-full px-3 py-2 rounded-xl bg-neutral-800 ring-1 ring-white/10">
+        <select value={form.cycle} onChange={e=>set('cycle', e.target.value)} className="mt-1 w-full px-3 py-2 rounded-xl bg-white dark:bg-neutral-800 ring-1 ring-black/10 dark:ring-white/10">
           <option value="weekly">Weekly</option>
           <option value="monthly">Monthly</option>
           <option value="yearly">Yearly</option>
@@ -357,18 +387,18 @@ function EditForm({ initial, onCancel, onSave, currency }){
       </label>
       {form.cycle === 'custom' && (
         <label className="text-sm">Interval (days)
-          <input type="number" min="1" value={form.intervalDays || 30} onChange={e=>set('intervalDays', parseInt(e.target.value)||30)} className="mt-1 w-full px-3 py-2 rounded-xl bg-neutral-800 ring-1 ring-white/10"/>
+          <input type="number" min="1" value={form.intervalDays || 30} onChange={e=>set('intervalDays', parseInt(e.target.value)||30)} className="mt-1 w-full px-3 py-2 rounded-xl bg-white dark:bg-neutral-800 ring-1 ring-black/10 dark:ring-white/10"/>
         </label>
       )}
       <label className="text-sm col-span-">Next due
-        <input type="date" value={form.nextDue} onChange={e=>set('nextDue', e.target.value)} className="mt-1 w-full px-3 py-2 rounded-xl bg-neutral-800 ring-1 ring-white/10"/>
+        <input type="date" value={form.nextDue} onChange={e=>set('nextDue', e.target.value)} className="mt-1 w-full px-3 py-2 rounded-xl bg-white dark:bg-neutral-800 ring-1 ring-black/10 dark:ring-white/10"/>
       </label>
       <label className="text-sm flex items-center gap-2 col-span-2 mt-1">
         <input type="checkbox" checked={!!form.autopay} onChange={e=>set('autopay', e.target.checked)} className="scale-110"/>
         Autopay enabled
       </label>
       <div className="col-span-2 flex justify-end gap-2 mt-2">
-        <button type="button" onClick={onCancel} className="px-3 py-2 rounded-xl bg-neutral-800">Cancel</button>
+        <button type="button" onClick={onCancel} className="px-3 py-2 rounded-xl bg-neutral-200 dark:bg-neutral-800">Cancel</button>
         <button type="submit" className="px-3 py-2 rounded-xl bg-white text-neutral-900 font-semibold">Save</button>
       </div>
     </form>
@@ -377,15 +407,15 @@ function EditForm({ initial, onCancel, onSave, currency }){
 
 function TableView({ rows, currency, lookahead, onChange, onDelete, onMarkPaid, onAdd }){
   return (
-    <div className="rounded-3xl bg-neutral-900/70 ring-1 ring-white/10 overflow-hidden">
+    <div className="rounded-3xl bg-neutral-100 dark:bg-neutral-900/70 ring-1 ring-black/10 dark:ring-white/10 overflow-hidden">
       <div className="flex items-center justify-between p-3">
-        <h3 className="text-sm text-neutral-400">Quick edit table</h3>
+        <h3 className="text-sm text-neutral-600 dark:text-neutral-400">Quick edit table</h3>
         <button onClick={onAdd} className="px-3 py-1.5 rounded-xl bg-white text-neutral-900 text-sm">Add Row</button>
       </div>
       <div className="overflow-auto">
         <table className="min-w-full text-sm">
-          <thead className="bg-neutral-900/80 sticky top-0">
-            <tr className="text-neutral-400">
+          <thead className="bg-neutral-200 dark:bg-neutral-900/80 sticky top-0">
+            <tr className="text-neutral-600 dark:text-neutral-400">
               <th className="text-left px-3 py-2">Name</th>
               <th className="text-left px-3 py-2">Category</th>
               <th className="text-left px-3 py-2">Amount</th>
@@ -405,11 +435,11 @@ function TableView({ rows, currency, lookahead, onChange, onDelete, onMarkPaid, 
               const dot = r.daysLeft < 0 ? 'hsl(0 90% 50%)' : dueColor(r.daysLeft, lookahead);
               return (
                 <tr key={r.id} className="border-t border-white/5">
-                  <td className="px-3 py-2"><input className="w-40 max-w-full px-2 py-1 rounded-lg bg-neutral-800 ring-1 ring-white/10" value={r.name} onChange={(e)=>onChange(r.id,{name:e.target.value})}/></td>
-                  <td className="px-3 py-2"><input className="w-32 px-2 py-1 rounded-lg bg-neutral-800 ring-1 ring-white/10" value={r.category||''} onChange={(e)=>onChange(r.id,{category:e.target.value})}/></td>
-                  <td className="px-3 py-2"><input type="number" step="0.01" min="0" className="w-28 px-2 py-1 rounded-lg bg-neutral-800 ring-1 ring-white/10" value={r.amount} onChange={(e)=>onChange(r.id,{amount:parseFloat(e.target.value)})}/></td>
+                  <td className="px-3 py-2"><input className="w-40 max-w-full px-2 py-1 rounded-lg bg-white dark:bg-neutral-800 ring-1 ring-black/10 dark:ring-white/10" value={r.name} onChange={(e)=>onChange(r.id,{name:e.target.value})}/></td>
+                  <td className="px-3 py-2"><input className="w-32 px-2 py-1 rounded-lg bg-white dark:bg-neutral-800 ring-1 ring-black/10 dark:ring-white/10" value={r.category||''} onChange={(e)=>onChange(r.id,{category:e.target.value})}/></td>
+                  <td className="px-3 py-2"><input type="number" step="0.01" min="0" className="w-28 px-2 py-1 rounded-lg bg-white dark:bg-neutral-800 ring-1 ring-black/10 dark:ring-white/10" value={r.amount} onChange={(e)=>onChange(r.id,{amount:parseFloat(e.target.value)})}/></td>
                   <td className="px-3 py-2">
-                    <select className="px-2 py-1 rounded-lg bg-neutral-800 ring-1 ring-white/10" value={r.cycle} onChange={(e)=>onChange(r.id,{cycle:e.target.value})}>
+                    <select className="px-2 py-1 rounded-lg bg-white dark:bg-neutral-800 ring-1 ring-black/10 dark:ring-white/10" value={r.cycle} onChange={(e)=>onChange(r.id,{cycle:e.target.value})}>
                       <option value="weekly">Weekly</option>
                       <option value="monthly">Monthly</option>
                       <option value="yearly">Yearly</option>
@@ -418,10 +448,10 @@ function TableView({ rows, currency, lookahead, onChange, onDelete, onMarkPaid, 
                   </td>
                   <td className="px-3 py-2">
                     {r.cycle==='custom' ? (
-                      <input type="number" min="1" className="w-24 px-2 py-1 rounded-lg bg-neutral-800 ring-1 ring-white/10" value={r.intervalDays||30} onChange={(e)=>onChange(r.id,{intervalDays:parseInt(e.target.value)||30})}/>
+                      <input type="number" min="1" className="w-24 px-2 py-1 rounded-lg bg-white dark:bg-neutral-800 ring-1 ring-black/10 dark:ring-white/10" value={r.intervalDays||30} onChange={(e)=>onChange(r.id,{intervalDays:parseInt(e.target.value)||30})}/>
                     ) : <span className="text-neutral-500">—</span>}
                   </td>
-                  <td className="px-3 py-2"><input type="date" className="px-2 py-1 rounded-lg bg-neutral-800 ring-1 ring-white/10" value={r.nextDue} onChange={(e)=>onChange(r.id,{nextDue:e.target.value})}/></td>
+                  <td className="px-3 py-2"><input type="date" className="px-2 py-1 rounded-lg bg-white dark:bg-neutral-800 ring-1 ring-black/10 dark:ring-white/10" value={r.nextDue} onChange={(e)=>onChange(r.id,{nextDue:e.target.value})}/></td>
                   <td className="px-3 py-2"><input type="checkbox" className="scale-110" checked={!!r.autopay} onChange={(e)=>onChange(r.id,{autopay:e.target.checked})}/></td>
                   <td className="px-3 py-2 whitespace-nowrap">{formatCurrency(monthly, currency)}</td>
                   <td className="px-3 py-2"><div className="flex items-center gap-2"><span className="inline-block w-2.5 h-2.5 rounded-full" style={{background:dot}}/> {days}d</div></td>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: "class",
   content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- allow switching between light, dark, and system themes
- persist theme choice and apply Tailwind dark class
- style components for both themes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b86eb393b8832990be9a942a98ef69